### PR TITLE
update stmlib url

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -12,4 +12,4 @@
 	url = https://github.com/pichenettes/avr-audio-bootloader.git
 [submodule "stmlib"]
 	path = stmlib
-	url = git@github.com:mqtthiqs/stmlib.git
+	url = https://github.com/mqtthiqs/stmlib.git


### PR DESCRIPTION
The `git@github.com:` url for the `stmlib` submodule doesn't work if you don't have permissions to the repository, using `https://` instead makes this possible to anyone.