### PR TITLE
Replace UCSB Erbe-Verb link w/Archive.org ver.

### DIFF
--- a/clouds.html
+++ b/clouds.html
@@ -55,7 +55,7 @@
             mode based on the reverb of the original firmware (itself
             based on a description of the Lexicon 480L), and inspired
             in design by
-            the <a href="http://www.makenoisemusic.com/erbe-verb.html">Erbe</a> <a href="http://www.mat.ucsb.edu/595M/?p=1373">Verb</a>,
+            the <a href="http://www.makenoisemusic.com/erbe-verb.html">Erbe</a> <a href="https://web.archive.org/web/20151202180930/http://www.mat.ucsb.edu/595M/?p=1373">Verb</a>,
             with CV control over all parameters. It is largely
             modeless, probably unrealistic and goes far beyond your
             traditional reverb;</li>


### PR DESCRIPTION
The original link is not longer valid, so, here's a link to the archive.org version, the latest one that's functional.